### PR TITLE
Support for serverless-runtime-babel plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ module.exports = function(S) {
     }
 
     autoinstallFunction(fn) {
-      if (!fn.runtime.match(/^nodejs/)) {
+      if (!fn.runtime.match(/^nodejs|^babel$/)) {
         // Ignore non-node functions
         return Promise.resolve();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-autoinstall",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Just extended the regex to allow also babel runtime.
